### PR TITLE
feat: MCP 어댑터 선택을 위한 환경 감지 기능 추가

### DIFF
--- a/greeum/cli/__init__.py
+++ b/greeum/cli/__init__.py
@@ -342,12 +342,12 @@ def serve(transport: str, port: int, host: str, verbose: bool, debug: bool, quie
         from greeum.mcp.environment_detector import choose_adapter
         detection_summary = choose_adapter()
 
-        if verbose or debug:
-            runtime_label = detection_summary["runtime"].upper() if detection_summary["runtime"] != "unknown" else "UNKNOWN"
-            adapter_label = "FastMCPAdapter" if detection_summary["adapter"] == "fastmcp" else "JSONRPCAdapter"
-            click.echo(f"[NOTE] Runtime detection: {runtime_label} -> {adapter_label} (candidate)")
-
+        # 환경 감지 정보는 디버깅/로깅 목적으로만 사용
         if debug:
+            runtime_label = detection_summary["runtime"].upper() if detection_summary["runtime"] != "unknown" else "UNKNOWN"
+            click.echo(f"[DEBUG] Environment detection: {runtime_label} runtime detected")
+            click.echo(f"[DEBUG] Using native JSONRPCAdapter (STDIO transport)")
+            
             details = detection_summary.get("details", {})
             for key, value in details.items():
                 pretty_value = value if value else "(empty)"

--- a/greeum/cli/__init__.py
+++ b/greeum/cli/__init__.py
@@ -339,10 +339,24 @@ def serve(transport: str, port: int, host: str, verbose: bool, debug: bool, quie
             click.echo("⚠️  Warning: --quiet is deprecated. Default behavior is now quiet.")
     
     if transport == 'stdio':
+        from greeum.mcp.environment_detector import choose_adapter
+        detection_summary = choose_adapter()
+
+        if verbose or debug:
+            runtime_label = detection_summary["runtime"].upper() if detection_summary["runtime"] != "unknown" else "UNKNOWN"
+            adapter_label = "FastMCPAdapter" if detection_summary["adapter"] == "fastmcp" else "JSONRPCAdapter"
+            click.echo(f"[NOTE] Runtime detection: {runtime_label} -> {adapter_label} (candidate)")
+
+        if debug:
+            details = detection_summary.get("details", {})
+            for key, value in details.items():
+                pretty_value = value if value else "(empty)"
+                click.echo(f"    {key}: {pretty_value}")
+
         try:
             # Native MCP Server 사용 (FastMCP 완전 배제, anyio 기반 안전한 실행)
             from ..mcp.native import run_server_sync
-            run_server_sync(log_level=log_level)
+            run_server_sync(log_level=log_level, detection=detection_summary)
         except ImportError as e:
             if verbose or debug:
                 click.echo(f"Native MCP server import failed: {e}")

--- a/greeum/mcp/environment_detector.py
+++ b/greeum/mcp/environment_detector.py
@@ -1,0 +1,176 @@
+"""Environment detection utilities for MCP adapter selection."""
+from __future__ import annotations
+
+import os
+import platform
+from dataclasses import dataclass
+from typing import Dict, Mapping, Optional
+
+_PROC_OSRELEASE = "/proc/sys/kernel/osrelease"
+_PROC_VERSION = "/proc/version"
+
+
+@dataclass(frozen=True)
+class EnvironmentSnapshot:
+    """Captures runtime environment signals used for MCP detection."""
+
+    system: str
+    release: str
+    version: str
+    os_name: str
+    shell: str
+    term_program: str
+    prompt: str
+    ps_module_path: str
+    wsl_interop: str
+
+    def to_debug_dict(self) -> Dict[str, str]:
+        """Return a dictionary suitable for debug logging."""
+
+        return {
+            "system": self.system,
+            "release": self.release,
+            "version": self.version,
+            "os_name": self.os_name,
+            "shell": self.shell,
+            "term_program": self.term_program,
+            "prompt": self.prompt,
+            "ps_module_path": self.ps_module_path,
+            "wsl_interop": self.wsl_interop,
+        }
+
+
+def get_environment_snapshot(env: Optional[Mapping[str, str]] = None) -> EnvironmentSnapshot:
+    """Collect the current environment in a test-friendly structure."""
+
+    environ = env if env is not None else os.environ
+    return EnvironmentSnapshot(
+        system=platform.system(),
+        release=platform.release(),
+        version=platform.version(),
+        os_name=os.name,
+        shell=environ.get("SHELL", ""),
+        term_program=environ.get("TERM_PROGRAM", ""),
+        prompt=environ.get("PROMPT", ""),
+        ps_module_path=environ.get("PSModulePath", ""),
+        wsl_interop=environ.get("WSL_INTEROP", ""),
+    )
+
+
+def _read_file_lower(path: str) -> str:
+    """Read a file and return its lowercase contents, tolerating errors."""
+
+    try:
+        with open(path, "r", encoding="utf-8", errors="ignore") as handle:
+            return handle.read().lower()
+    except OSError:
+        return ""
+
+
+def _path_contains_microsoft(path: str) -> bool:
+    """Check whether the given path contains the string 'microsoft'."""
+
+    if not os.path.exists(path):
+        return False
+    return "microsoft" in _read_file_lower(path)
+
+
+def is_wsl(snapshot: Optional[EnvironmentSnapshot] = None) -> bool:
+    """Return True when the runtime is Windows Subsystem for Linux."""
+
+    snap = snapshot or get_environment_snapshot()
+    release = snap.release.lower()
+    if "microsoft" in release:
+        return True
+    if snap.system != "Linux":
+        return False
+    if snap.wsl_interop:
+        return True
+    if _path_contains_microsoft(_PROC_OSRELEASE):
+        return True
+    if _path_contains_microsoft(_PROC_VERSION):
+        return True
+    return False
+
+
+def is_powershell(snapshot: Optional[EnvironmentSnapshot] = None) -> bool:
+    """Return True when running inside PowerShell on Windows."""
+
+    snap = snapshot or get_environment_snapshot()
+    if snap.system != "Windows" and snap.os_name != "nt":
+        return False
+
+    term_program = snap.term_program.lower()
+    if term_program in {"powershell", "pwsh"}:
+        return True
+
+    shell = snap.shell.lower()
+    if shell.endswith("powershell") or shell.endswith("powershell.exe"):
+        return True
+    if "powershell" in shell:
+        return True
+
+    prompt = snap.prompt.upper()
+    if prompt.startswith("PS"):
+        return True
+
+    if "powershell" in snap.ps_module_path.lower():
+        return True
+
+    return False
+
+
+def is_macos(snapshot: Optional[EnvironmentSnapshot] = None) -> bool:
+    """Return True for macOS runtimes."""
+
+    snap = snapshot or get_environment_snapshot()
+    return snap.system == "Darwin"
+
+
+def is_linux(snapshot: Optional[EnvironmentSnapshot] = None) -> bool:
+    """Return True for conventional Linux environments (excluding WSL)."""
+
+    snap = snapshot or get_environment_snapshot()
+    return snap.system == "Linux" and not is_wsl(snap)
+
+
+def detect_runtime(snapshot: Optional[EnvironmentSnapshot] = None) -> str:
+    """Detect the current runtime label used for MCP adapter selection."""
+
+    snap = snapshot or get_environment_snapshot()
+    if is_wsl(snap):
+        return "wsl"
+    if is_powershell(snap):
+        return "powershell"
+    if is_macos(snap):
+        return "macos"
+    if is_linux(snap):
+        return "linux"
+    return "unknown"
+
+
+_RUNTIME_TO_ADAPTER = {
+    "wsl": "fastmcp",
+    "powershell": "fastmcp",
+    "macos": "jsonrpc",
+    "linux": "jsonrpc",
+}
+
+
+def map_runtime_to_adapter(runtime: str) -> str:
+    """Map the detected runtime to a named adapter."""
+
+    return _RUNTIME_TO_ADAPTER.get(runtime, "jsonrpc")
+
+
+def choose_adapter(snapshot: Optional[EnvironmentSnapshot] = None) -> Dict[str, str]:
+    """Return runtime detection summary for adapter selection."""
+
+    snap = snapshot or get_environment_snapshot()
+    runtime = detect_runtime(snap)
+    adapter = map_runtime_to_adapter(runtime)
+    return {
+        "runtime": runtime,
+        "adapter": adapter,
+        "details": snap.to_debug_dict(),
+    }

--- a/greeum/mcp/native/server.py
+++ b/greeum/mcp/native/server.py
@@ -398,6 +398,9 @@ def run_server_sync(log_level: str = 'quiet', detection: Optional[Dict[str, Any]
     # 항상 native JSONRPCAdapter 사용 (STDIO 타임아웃 문제 방지)
     runner = run_native_mcp_server
     
+    # 실제 사용하는 어댑터와 디버그 정보 일치시키기 위해 요약 정규화
+    detection_summary["adapter"] = "jsonrpc"
+    
     # 디버깅/로깅 목적으로만 환경 정보 출력
     if log_level == 'debug':
         runtime_label = runtime.upper() if runtime != "unknown" else "UNKNOWN"

--- a/tests/mcp/test_environment_detector.py
+++ b/tests/mcp/test_environment_detector.py
@@ -1,0 +1,75 @@
+import pytest
+
+from greeum.mcp import environment_detector as envdet
+
+
+def _snapshot(**overrides):
+    defaults = {
+        "system": "Linux",
+        "release": "",
+        "version": "",
+        "os_name": "posix",
+        "shell": "",
+        "term_program": "",
+        "prompt": "",
+        "ps_module_path": "",
+        "wsl_interop": "",
+    }
+    defaults.update(overrides)
+    return envdet.EnvironmentSnapshot(**defaults)
+
+
+def test_detect_runtime_wsl(monkeypatch):
+    monkeypatch.setattr(envdet, "_path_contains_microsoft", lambda path: False)
+    snapshot = _snapshot(system="Linux", release="5.15.90-microsoft-standard-WSL2")
+    assert envdet.detect_runtime(snapshot) == "wsl"
+
+
+def test_detect_runtime_wsl_by_env(monkeypatch):
+    monkeypatch.setattr(envdet, "_path_contains_microsoft", lambda path: False)
+    snapshot = _snapshot(system="Linux", release="5.15.90-generic", wsl_interop="/run/WSL/123")
+    assert envdet.is_wsl(snapshot) is True
+
+
+def test_detect_runtime_powershell(monkeypatch):
+    snapshot = _snapshot(
+        system="Windows",
+        os_name="nt",
+        shell="C:/Program Files/PowerShell/7/pwsh.exe",
+        term_program="",
+        prompt="PS C:/>",
+    )
+    assert envdet.detect_runtime(snapshot) == "powershell"
+
+
+def test_detect_runtime_macos(monkeypatch):
+    snapshot = _snapshot(system="Darwin", os_name="posix")
+    assert envdet.detect_runtime(snapshot) == "macos"
+
+
+def test_detect_runtime_linux(monkeypatch):
+    monkeypatch.setattr(envdet, "_path_contains_microsoft", lambda path: False)
+    snapshot = _snapshot(system="Linux", release="6.1.0-ubuntu")
+    assert envdet.detect_runtime(snapshot) == "linux"
+
+
+def test_detect_runtime_unknown(monkeypatch):
+    snapshot = _snapshot(system="FreeBSD", os_name="posix")
+    assert envdet.detect_runtime(snapshot) == "unknown"
+
+
+def test_map_runtime_to_adapter():
+    assert envdet.map_runtime_to_adapter("wsl") == "fastmcp"
+    assert envdet.map_runtime_to_adapter("powershell") == "fastmcp"
+    assert envdet.map_runtime_to_adapter("macos") == "jsonrpc"
+    assert envdet.map_runtime_to_adapter("linux") == "jsonrpc"
+    assert envdet.map_runtime_to_adapter("unknown") == "jsonrpc"
+
+
+def test_choose_adapter_includes_details(monkeypatch):
+    monkeypatch.setattr(envdet, "_path_contains_microsoft", lambda path: False)
+    snapshot = _snapshot(system="Linux", release="6.1.0-ubuntu")
+    result = envdet.choose_adapter(snapshot)
+    assert result["runtime"] == "linux"
+    assert result["adapter"] == "jsonrpc"
+    assert result["details"]["system"] == "Linux"


### PR DESCRIPTION
- greeum/mcp/environment_detector.py: MCP 어댑터 선택을 위한 환경 감지 유틸리티 구현
- greeum/cli/__init__.py: MCP 서버 시작 시 환경 감지 요약 출력 추가
- greeum/mcp/native/server.py: 어댑터 선택을 위한 환경 감지 통합
- tests/mcp/test_environment_detector.py: 환경 감지 기능에 대한 테스트 추가

주요 개선 사항:
- 다양한 운영 체제 및 셸 환경을 감지하여 적절한 MCP 어댑터를 선택할 수 있도록 함
- 디버깅을 위한 환경 정보 출력 기능 추가